### PR TITLE
Fix color3 reading

### DIFF
--- a/src/dataTypes/color3.luau
+++ b/src/dataTypes/color3.luau
@@ -12,7 +12,7 @@ local color3 = {
 		uint8NoAlloc(input.B * 255)
 	end,
 	read = function(b: buffer, cursor: number)
-		return Color3.new(buffer.readu8(b, cursor), buffer.readu8(b, cursor + 1), buffer.readu8(b, cursor + 2)), 3
+		return Color3.fromRGB(buffer.readu8(b, cursor), buffer.readu8(b, cursor + 1), buffer.readu8(b, cursor + 2)), 3
 	end,
 }
 


### PR DESCRIPTION
Color3.new expects values between 0-1

Currently, we are passing in values 0-255 in the color3.luau read function

Use the fromRGB instead to correctly accept 0-255