### PR TITLE
fix: Per player channel doesn't exist when sending data

### DIFF
--- a/src/process/server.luau
+++ b/src/process/server.luau
@@ -73,6 +73,9 @@ function serverProcess.sendPlayerReliable(
 	writer: (value: any) -> (),
 	data: { [string]: any }
 )
+	if not perPlayerReliable[player] then
+		perPlayerReliable[player] = create()
+	end
 	perPlayerReliable[player] = writePacket(perPlayerReliable[player], id, writer, data)
 end
 
@@ -82,6 +85,9 @@ function serverProcess.sendPlayerUnreliable(
 	writer: (value: any) -> (),
 	data: { [string]: any }
 )
+	if not perPlayerUnreliable[player] then
+		perPlayerUnreliable[player] = create()
+	end
 	perPlayerUnreliable[player] = writePacket(perPlayerUnreliable[player], id, writer, data)
 end
 


### PR DESCRIPTION
When trying to fire an event on `PlayerAdded`, the channel for the player isn't created yet and the code errors. This is due to the lack(?) of ordering for `PlayerAdded`.

The server process now creates the channel for the player if one doesn't exist yet when adding data to the outgoing queue.
Fixes #22 