### PR TITLE
Packet.luau

### DIFF
--- a/src/packets/packet.luau
+++ b/src/packets/packet.luau
@@ -85,25 +85,20 @@ return function(props: types.packetProps<types.dataTypeInterface<any>>, id: numb
 
 	function exported.wait()
 		-- define it up here so we can use it to disconnect
-		local index: number
-
 		local runningThread = coroutine.running()
-		table.insert(listeners, function(data, player)
+		local Callback: (any,Player) -> () 
+		Callback = function(data, player)
 			task.spawn(runningThread, data, player)
-
-			-- Disconnects the listener
-			table.remove(listeners, index)
-		end)
-
-		-- we connected, time to set the index for when we need to disconnect.
-		index = #listeners
-
-		-- the listener will resume the thread
+			table.remove(listeners,table.find(listeners,Callback))
+		end
+		table.insert(listeners, Callback)
 		return coroutine.yield()
 	end
-
 	function exported.listen(callback)
 		table.insert(listeners, callback)
+		return function()
+			table.remove(listeners,table.find(listeners, callback))
+		end
 	end
 
 	function exported.getListeners()

--- a/src/process/read.luau
+++ b/src/process/read.luau
@@ -35,7 +35,15 @@ return function(incomingBuffer: buffer, references: { [number]: unknown }?, play
 	readRefs.set(references)
 
 	while readCursor < length do
-		local packet = ref[buffer.readu8(incomingBuffer, readCursor)]
+		local packet
+		while true do 
+			packet = ref[buffer.readu8(incomingBuffer, readCursor)]
+			if not packet then
+				task.wait()
+			else
+				break
+			end
+		end
 		readCursor += 1
 
 		local value, valueLength = packet.reader(incomingBuffer, readCursor)

--- a/src/process/server.luau
+++ b/src/process/server.luau
@@ -101,7 +101,10 @@ function serverProcess.start()
 	end
 
 	Players.PlayerAdded:Connect(playerAdded)
-
+	Players.PlayerRemoving:Connect(function(Player)
+		perPlayerReliable[Player] = nil
+		perPlayerUnreliable[Player] = nil
+	end)
 	RunService.Heartbeat:Connect(function()
 		-- Check if the channel has anything before trying to send it
 		if globalReliable.cursor > 0 then


### PR DESCRIPTION
packets.luau
Edited wait() that uses table.find on the callback function (storing the index caused weird issues) Added a disconnect function that's returned in .listen [Haven't added an addendum to the type for that]

server.luau
Added PlayerRemoving connections to clean up the tables

read.luau
Added yielding for packets sent before the client has initialised ByteNet (could EQUALLY be replaced with an error message ngl)